### PR TITLE
Add option to wait for API when signing Planetary Computer urls.

### DIFF
--- a/R/signatures.R
+++ b/R/signatures.R
@@ -182,12 +182,14 @@ sign_planetary_computer <- function(..., token_url = NULL, retry=FALSE) {
         )
 
 
-    if (!"token" %in% names(res_content))
+    if (!"token" %in% names(res_content)){
       if ("message" %in% names(res_content)){
-        .error(res_content$messgage)
+        .error("%s", res_content$message)
       } else {
         .error("No collection found with id '%s'", item$collection)
       }
+    }
+
 
     token[[item$collection]] <<- parse(res_content)
   }

--- a/R/signatures.R
+++ b/R/signatures.R
@@ -146,7 +146,7 @@ sign_planetary_computer <- function(..., token_url = NULL, retry=FALSE) {
 
     # transform to a datetime object
     obj_req[["msft:expiry"]] <- strptime(obj_req[["msft:expiry"]],
-                                         "%Y-%m-%dT%H:%M:%SZ")
+                                         "%Y-%m-%dT%H:%M:%SZ", tz="UTC")
 
     token_str <- paste0("?", obj_req[["token"]])
     obj_req[["token_value"]] <- httr::parse_url(token_str)[["query"]]

--- a/R/utils.R
+++ b/R/utils.R
@@ -504,7 +504,7 @@ stac_version <- function(x, ...) {
 retry_mpc_request <- function(.f, .url, .req, .n, .item){
 
   sleep_request <- function(s, f, c_url){
-      message(crayon::cyan(s))
+      message(crayon::cyan(gsub("Try", "Trying", s, fixed = TRUE)))
       Sys.sleep(as.numeric(gsub(".*in (.+) seconds.*", "\\1", s))+1)
       f(c_url)
   }


### PR DESCRIPTION
So, further to this issue: https://github.com/brazil-data-cube/rstac/issues/105, I have added some functionality to handle the rate limit on the signing API. 

This includes adding a `retry=FALSE` argument to `sign_planetary_computer` which therefore won't change the default behaviour. 

I've also added a more informative error when the failure is due to the API rate. 

May thanks,
Hugh