### PR TITLE
Time Zone issue fix for MPC token signing

### DIFF
--- a/R/signatures.R
+++ b/R/signatures.R
@@ -182,12 +182,14 @@ sign_planetary_computer <- function(..., token_url = NULL, retry=FALSE) {
         )
 
 
-    if (!"token" %in% names(res_content))
+    if (!"token" %in% names(res_content)){
       if ("message" %in% names(res_content)){
-        .error(res_content$messgage)
+        .error("%s", res_content$message)
       } else {
         .error("No collection found with id '%s'", item$collection)
       }
+    }
+
 
     token[[item$collection]] <<- parse(res_content)
   }

--- a/R/signatures.R
+++ b/R/signatures.R
@@ -146,7 +146,7 @@ sign_planetary_computer <- function(..., token_url = NULL, retry=FALSE) {
 
     # transform to a datetime object
     obj_req[["msft:expiry"]] <- strptime(obj_req[["msft:expiry"]],
-                                         "%Y-%m-%dT%H:%M:%SZ")
+                                         "%Y-%m-%dT%H:%M:%SZ", tz="UTC")
 
     token_str <- paste0("?", obj_req[["token"]])
     obj_req[["token_value"]] <- httr::parse_url(token_str)[["query"]]

--- a/R/utils.R
+++ b/R/utils.R
@@ -504,7 +504,7 @@ stac_version <- function(x, ...) {
 retry_mpc_request <- function(.f, .url, .req, .n, .item){
 
   sleep_request <- function(s, f, c_url){
-      message(crayon::cyan(s))
+      message(crayon::cyan(gsub("Try", "Trying", s, fixed = TRUE)))
       Sys.sleep(as.numeric(gsub(".*in (.+) seconds.*", "\\1", s))+1)
       f(c_url)
   }


### PR DESCRIPTION
Okay, so the first two commits on this PR seek to retry an API token request if the rate has been exceeded. In reality this may not be required. 

The actual bug was is fixed in the third commit. token expiry terms were not assigned with a specified time zone and so (for me) this resulted in constant expiry and repeated requests. 

Cheers