### PR TITLE
Fix bug in `collections_next()`: use `check_collections()` rather than `check_collection()` on `collections` object

### DIFF
--- a/R/collections-funs.R
+++ b/R/collections-funs.R
@@ -72,7 +72,7 @@ NULL
 #'
 #' @export
 collections_next <- function(collections, ...) {
-  check_collection(collections)
+  check_collections(collections)
   # get url of the next page
   rel <- NULL
   next_link <- links(collections, rel == "next")


### PR DESCRIPTION
I hope I've made this PR against the correct branch, as `master` doesn't have `collections_next()` and `collections_fetch()`

This was failing with the example in `?collections_next()`:

``` r
stac("https://cmr.earthdata.nasa.gov/stac/LPCLOUD") |>
  collections() |>
  get_request() |>
  collections_next()
#> Error: Invalid doc_collection object. Expecting `id` key.
```

With this fix it now works:

``` r
library(rstac)

stac("https://cmr.earthdata.nasa.gov/stac/LPCLOUD") |>
  collections() |>
  get_request() |>
  collections_next()
#> ###Collections
#> - collections (20 item(s)):
#>   - ECO_L3G_SEB_002
#>   - ECO_L1CG_RAD_002
#>   - ECO_L4G_WUE_002
#>   - ECO_L1B_ATT_002
#>   - ECO_L2_CLOUD_002
#>   - ECO_L1B_GEO_002
#>   - ECO_L2_LSTE_002
#>   - ECO_L1B_RAD_002
#>   - ECO_L2T_STARS_002
#>   - ECO_L3T_MET_002
#>   - ... with 10 more collection(s).
#> - field(s): description, links, collections
```

<sup>Created on 2025-05-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>