### PR TITLE
Switch to `if (...) else` in `simplify_vector_argument()`

### DIFF
--- a/R/request.R
+++ b/R/request.R
@@ -88,5 +88,5 @@ post_request <- function(q, simplify_vector = NULL, ..., encode = c("json", "mul
 }
 
 simplify_vector_argument <- function(simplify_vector = NULL) {
-  ifelse(!is.null(simplify_vector), simplify_vector, getOption("rstac.simplify_vector", default = TRUE))
+  if (!is.null(simplify_vector)) simplify_vector else getOption("rstac.simplify_vector", default = TRUE)
 }


### PR DESCRIPTION
As per @rolfsimoes' suggestion https://github.com/brazil-data-cube/rstac/pull/180#discussion_r2355337529/:

> One small suggestion on this line. Since `simplify_vector` is expected to be a single logical value, it might be clearer and more idiomatic to use a standard `if (...) else` statement:
> 
> ```r
> if (!is.null(simplify_vector)) simplify_vector else getOption("rstac.simplify_vector", default = TRUE)
> ```
> 
> This avoids the vectorized behavior of `ifelse()` and aligns better with typical usage for scalar conditions. Just a readability/clarity suggestion. Feel free to take or leave it.